### PR TITLE
Capture unmatched lines

### DIFF
--- a/lib/fluent/plugin/in_tail.rb
+++ b/lib/fluent/plugin/in_tail.rb
@@ -362,7 +362,7 @@ module Fluent::Plugin
             if @enable_catch_all
               record = {'parse_fail' => line}
               record[@path_key] ||= tail_watcher.path unless @path_key.nil?
-              es.add(Fluent::EventTime.now, record)
+              es.add(Time.now.to_i, record)
             end
             log.warn "pattern not match: #{line.inspect}"
           end


### PR DESCRIPTION
Essentially all unmatched lines will be placed inside the parse_fail attribute, i.e.
```
{  
   "parse_fail":"unmatched line....rest of the line",
   "server":"myserver",
   "stack":"my-app-dev-01",
   "application":"my-app",
   "log_type":"apache.access",
   "time":"2017-01-16T23:06:49Z"
}
```

This will enable our analytics tools to pick up any pattern matching regexp issues.